### PR TITLE
Add composer.json for use in PHP projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 supplementalData.xml
+/vendor/
+/composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "wikimedia/language-data",
+    "description": "Language data and utilities",
+    "license": "GPL-2.0-or-later OR MIT",
+    "authors": [
+        {
+            "name": "Santhosh Thottingal",
+            "email": "santhosh.thottingal@gmail.com"
+        }
+    ]
+}


### PR DESCRIPTION
So MediaWiki core can depend on and use it.

Signed-off-by: Kunal Mehta <legoktm@member.fsf.org>

(Also where is the bug tracker for this project?)