### PR TITLE
Add qwh (Ancash Quechua)

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -427,6 +427,7 @@ languages:
   qu: [Latn, [AM], Runa Simi]
   quc: [Latn, [AM], "K'iche'"]
   qug: [Latn, [AM], Runa shimi]
+  qwh: [Latn, [AM], anqash qichwa]
   rap: [Latn, [AM], arero rapa nui]
   rcf: [Latn, [AF], Kreol Réyoné]
   rgn: [Latn, [EU], Rumagnôl]

--- a/language-data.json
+++ b/language-data.json
@@ -2771,6 +2771,13 @@
             ],
             "Runa shimi"
         ],
+        "qwh": [
+            "Latn",
+            [
+                "AM"
+            ],
+            "anqash qichwa"
+        ],
         "rap": [
             "Latn",
             [


### PR DESCRIPTION
Requested at translatewiki:
https://translatewiki.net/wiki/Thread:Support/support_for_Huaylas_Ancash_Quechua

Source for autonym spelling:
http://www.illa-a.org/wp/diccionarios/