### PR TITLE
Allow limiting languages in getLanguagesByScriptGroupInRegion and add a test

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,15 +164,22 @@ function getLanguagesByScriptGroup( languages ) {
  * @param {string[]} regions array of region codes
  * @return {Object}
  */
-function getLanguagesByScriptGroupInRegions( regions ) {
-	var language, i, scriptGroup,
+function getLanguagesByScriptGroupInRegions( regions, languages ) {
+	var language, languageIndex, regionIndex, scriptGroup,
 		languagesByScriptGroupInRegions = {};
-	for ( language in languageData.languages ) {
+
+	if ( languages === undefined ) {
+		languages = Object.keys( languageData.languages );
+	}
+
+	for ( languageIndex = 0; languageIndex < languages.length; languageIndex++ ) {
+		language = languages[ languageIndex ];
+
 		if ( isRedirect( language ) ) {
 			continue;
 		}
-		for ( i = 0; i < regions.length; i++ ) {
-			if ( getRegions( language ).includes( regions[ i ] ) ) {
+		for ( regionIndex = 0; regionIndex < regions.length; regionIndex++ ) {
+			if ( getRegions( language ).includes( regions[ regionIndex ] ) ) {
 				scriptGroup = getScriptGroupOfLanguage( language );
 				if ( languagesByScriptGroupInRegions[ scriptGroup ] === undefined ) {
 					languagesByScriptGroupInRegions[ scriptGroup ] = [];
@@ -191,8 +198,8 @@ function getLanguagesByScriptGroupInRegions( regions ) {
  * @param {string} region Region code
  * @return {Object}
  */
-function getLanguagesByScriptGroupInRegion( region ) {
-	return getLanguagesByScriptGroupInRegions( [ region ] );
+function getLanguagesByScriptGroupInRegion( region, languages ) {
+	return getLanguagesByScriptGroupInRegions( [ region ], languages );
 }
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -140,11 +140,21 @@ describe( 'languagedata', function () {
 		assert.ok( languageData.getLanguagesInTerritory( 'RU' ).includes( 'sah' ), 'Sakha language is spoken in Russia' );
 	} );
 	it( 'scripts', function () {
+		var languagesAM = [ "atj", "gn", "en", "es", "fr", "haw", "ike-cans", "ik", "kl", "nl", "cr", "pt", "qu", "srn", "chr", "chy", "yi" ];
 		// This test assumes that we don't want any scripts to be in the 'Other'
 		// group. Actually, this may become wrong some day.
 		assert.deepEqual( orphanScripts(), [], 'All scripts belong to script groups.' );
 		assert.deepEqual( languageData.getLanguagesInScript( 'Guru' ), [ 'pa-guru' ], '"pa-guru" is written in script Guru, and "pa" is skipped as a redirect' );
 		assert.deepEqual( languageData.getLanguagesInScripts( [ 'Geor', 'Armn' ] ), [ 'hy', 'hyw', 'ka', 'xmf' ], 'languages in scripts Geor and Armn are selected correctly' );
+		assert.deepEqual(
+			languageData.getLanguagesByScriptGroupInRegion( 'AM', languagesAM ),
+			{
+				"Latin": [ "atj", "gn", "en", "es", "fr", "haw", "ik", "kl", "nl", "pt", "qu", "srn", "chy" ],
+				"MiddleEastern": [ "yi" ],
+				"NativeAmerican": [ "ike-cans", "cr", "chr" ]
+			},
+			'languages in region AM are grouped correctly'
+		);
 		assert.deepEqual( languageData.getLanguagesInScript( 'Knda' ), [
 			'kn', 'tcy'
 		], 'languages in script Knda are selected correctly' );


### PR DESCRIPTION
This is a step towards resolving downstream bug
https://phabricator.wikimedia.org/T189090

The next step is to add a function that uses getLanguagesByScriptGroupInRegion
and orders the languages by autonym.