### PR TITLE
Changed the name of the gcr language

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -193,7 +193,7 @@ languages:
   gbm: [Deva, [AS], गढ़वळि]
   gbz: [Latn, [AS], Dari-e Mazdeyasnā]
   gcf: [Latn, [AM], Guadeloupean Creole French]
-  gcr: [Latn, [AM], kréyòl gwiyanè]
+  gcr: [Latn, [AM], kriyòl gwiyannen]
   gd: [Latn, [EU], Gàidhlig]
   gez: [Ethi, [AF], ግዕዝ]
   gl: [Latn, [EU], galego]

--- a/language-data.json
+++ b/language-data.json
@@ -1208,7 +1208,7 @@
             [
                 "AM"
             ],
-            "kréyòl gwiyanè"
+            "kriyòl gwiyannen"
         ],
         "gd": [
             "Latn",


### PR DESCRIPTION
Changed the name of the (gcr) language from "Kreyol Gwiyanè" to "Kriyòl Gwiyannen"

Per: https://translatewiki.net/wiki/Thread:Support/Need_Help_!