### PR TITLE
Change the autonym of Javanese from "Basa Jawa" to "Jawa"

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -260,9 +260,9 @@ languages:
   jdt: [jdt-cyrl]
   jdt-cyrl: [Cyrl, [EU, AS], жугьури]
   jut: [Latn, [EU], jysk]
-  jv: [Latn, [AS, PA], Basa Jawa]
+  jv: [Latn, [AS, PA], Jawa]
  # For support in webfonts.
-  jv-java: [Java, [AS, PA], ꦧꦱꦗꦮ]
+  jv-java: [Java, [AS, PA], ꦗꦮ]
   jv-x-bms: [Latn, [AS], Basa Banyumasan]
   ka: [Geor, [EU], ქართული]
   kaa: [Latn, [AS], Qaraqalpaqsha]

--- a/language-data.json
+++ b/language-data.json
@@ -1653,7 +1653,7 @@
                 "AS",
                 "PA"
             ],
-            "Basa Jawa"
+            "Jawa"
         ],
         "jv-java": [
             "Java",
@@ -1661,7 +1661,7 @@
                 "AS",
                 "PA"
             ],
-            "ꦧꦱꦗꦮ"
+            "ꦗꦮ"
         ],
         "jv-x-bms": [
             "Latn",


### PR DESCRIPTION
The word "Basa" simply means "language" and it is unnecessary.

This was requested at the Javanese Wikipedia village pump:
https://jv.wikipedia.org/w/index.php?title=Wikipedia:Warung_Kopi&oldid=1478057#Jawa_utawa_Basa_Jawa