### PR TITLE
Rename "Baso Minangkabau" to "Minangkabau"

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -356,7 +356,7 @@ languages:
   mhr: [Cyrl, [EU], олык марий]
   mi: [Latn, [PA], Māori]
   mic: [Latn, [AM], "Mi'kmaq"]
-  min: [Latn, [AS], Baso Minangkabau]
+  min: [Latn, [AS], Minangkabau]
   miq: [Latn, [AM], Mískitu]
   mk: [Cyrl, [EU], македонски]
   ml: [Mlym, [AS, ME], മലയാളം]

--- a/language-data.json
+++ b/language-data.json
@@ -2275,7 +2275,7 @@
             [
                 "AS"
             ],
-            "Baso Minangkabau"
+            "Minangkabau"
         ],
         "miq": [
             "Latn",


### PR DESCRIPTION
Addresses downstream issue
https://phabricator.wikimedia.org/T224806

This was already changed in MediaWiki core.