### PR TITLE
Change the autonym of Manipuri to Meetei script

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -363,7 +363,8 @@ languages:
  # Hmm, can also have Mong some day in some way
   mn: [Cyrl, [AS], монгол]
   mnc: [Mong, [AS], ᠮᠠᠨᠵᡠ ᡤᡳᠰᡠᠨ]
-  mni: [Beng, [AS], মেইতেই লোন্]
+  mni: [Mtei, [AS], ꯃꯤꯇꯩ ꯂꯣꯟ]
+  mni-beng: [Beng, [AS], মেইতেই লোন্]
   mnw: [Mymr, [AS], ဘာသာ မန်]
   mo: [Cyrl, [EU], молдовеняскэ]
   moe: [Latn, [AM], Innu-aimun]
@@ -664,7 +665,7 @@ scriptgroups:
  # Tibetan (Tibt) is here, even though it's classified as "Central Asian" by
  # Unicode, because linguistically and geographically it's closely related to
  # the Brahmic family.
-  SouthAsian: [Beng, Deva, Gujr, Guru, Knda, Mlym, Olck, Orya, Saur, Sinh, Taml, Telu, Tibt, Thaa, Wara]
+  SouthAsian: [Beng, Deva, Gujr, Guru, Knda, Mlym, Mtei, Olck, Orya, Saur, Sinh, Taml, Telu, Tibt, Thaa, Wara]
   Cyrillic: [Cyrl]
   CJK: [Hans, Hant, Kana, Kore, Jpan, Yiii]
   SouthEastAsian: [Bali, Batk, Bugi, Java, Khmr, Laoo, Mymr, Thai]

--- a/language-data.json
+++ b/language-data.json
@@ -2314,6 +2314,13 @@
             "ᠮᠠᠨᠵᡠ ᡤᡳᠰᡠᠨ"
         ],
         "mni": [
+            "Mtei",
+            [
+                "AS"
+            ],
+            "ꯃꯤꯇꯩ ꯂꯣꯟ"
+        ],
+        "mni-beng": [
             "Beng",
             [
                 "AS"
@@ -4108,6 +4115,7 @@
             "Guru",
             "Knda",
             "Mlym",
+            "Mtei",
             "Olck",
             "Orya",
             "Saur",


### PR DESCRIPTION
This also adds the support for the Meetei Mayek script
(ISO 15924: Mtei) to langdb.

Meetei Mayek script is the one used in schools in Manipur
(see the Wikipedia article [[Meitei script]] for references).
It is also the script that is used for all the translations
in translatewiki [1] and for all the test articles
in the Wikimedia Incubator.[2]

The Bengali script version is preserved with a tag,
because the Bengali script may be used as well.

[1] https://translatewiki.net/w/i.php?title=Special:Translate&filter=translated&group=mediawiki&language=mni&action=translate
[2] https://incubator.wikimedia.org/wiki/Special:PrefixIndex/wp/mni