### PR TITLE
Moroccan Arabic (ary) native name

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -27,7 +27,7 @@ languages:
   arn: [Latn, [AM], mapudungun]
   aro: [Latn, [AM], Araona]
   arq: [Arab, [AF], جازايرية]
-  ary: [Latn, [ME], الدارجة]
+  ary: [Arab, [AF], الدارجة]
   arz: [Arab, [ME], مصرى]
   as: [Beng, [AS], অসমীয়া]
   ase: [Sgnw, [AM], American sign language]

--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -27,7 +27,7 @@ languages:
   arn: [Latn, [AM], mapudungun]
   aro: [Latn, [AM], Araona]
   arq: [Arab, [AF], جازايرية]
-  ary: [Latn, [ME], Maġribi]
+  ary: [Latn, [ME], الدارجة]
   arz: [Arab, [ME], مصرى]
   as: [Beng, [AS], অসমীয়া]
   ase: [Sgnw, [AM], American sign language]


### PR DESCRIPTION
I propose to change it into {الدارجة} instead of {Maġribi}; refs:
1- [https://www.ethnologue.com/language/ary] (section autonym)
2- [https://en.wikipedia.org/Moroccan_Arabic]