### PR TITLE
Run ulsdata2json.php

### DIFF
--- a/language-data.json
+++ b/language-data.json
@@ -3258,9 +3258,6 @@
             ],
             "tacawit"
         ],
-        "shy": [
-            "shy-latn"
-        ],
         "si": [
             "Sinh",
             [
@@ -4605,7 +4602,6 @@
             "ar",
             "fr",
             "kab",
-            "shy-latn",
             "en"
         ],
         "EA": [
@@ -5687,7 +5683,6 @@
         "TW": [
             "zh-hant",
             "zh",
-            "szy",
             "trv"
         ],
         "TZ": [


### PR DESCRIPTION
This removes szy and shy from language-data.json,
which are not standard in CLDR for the territories.
They should be added differently.