### PR TITLE
Update minimum supported node.js version to 8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "url": "http://github.com/wikimedia/language-data/issues"
   },
   "engine": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "license": "GPL-2.0-or-later",
   "scripts": {


### PR DESCRIPTION
Fixes failing test case on node.js version 6.

```
> @wikimedia/language-data@0.1.2 test /home/abijeet/Development/Projects/php/code/language-data
> mocha tests/js/*.js



  languagedata
    ✓ language tags
    ✓ autonyms
    1) regions and groups
    ✓ scripts
    ✓ redirects
    ✓ directionality


  5 passing (20ms)
  1 failing

  1) languagedata
       regions and groups:

      AssertionError: languages in region AM are ordered correctly by script group
      + expected - actual

         "qu"
         "srn"
         "chy"
         "yi"
      -  "chr"
         "ike-cans"
         "cr"
      +  "chr"
       ]
      
      at Context.<anonymous> (tests/js/index.js:129:10)



npm ERR! Test failed.  See above for more details.
```