### PR TITLE
Add Sylheti

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -519,6 +519,9 @@ languages:
   skr-arab: [Arab, [AS], سرائیکی]
   skr: [skr-arab]
   syc: [Syrc, [ME], ܣܘܪܝܝܐ]
+  syl: [Sylo, [AS], ꠍꠤꠟꠐꠤ]
+  syl-beng: [Beng, [AS], সিলেটি]
+  syl-sylo: [syl]
   sm: [Latn, [PA], Gagana Samoa]
   sma: [Latn, [EU], åarjelsaemien]
   smj: [Latn, [EU], julevsámegiella]
@@ -673,7 +676,7 @@ scriptgroups:
  # Tibetan (Tibt) is here, even though it's classified as "Central Asian" by
  # Unicode, because linguistically and geographically it's closely related to
  # the Brahmic family.
-  SouthAsian: [Beng, Cakm, Deva, Gujr, Guru, Knda, Mlym, Mtei, Olck, Orya, Saur, Sinh, Taml, Telu, Tibt, Thaa, Wara]
+  SouthAsian: [Beng, Cakm, Deva, Gujr, Guru, Knda, Mlym, Mtei, Olck, Orya, Saur, Sinh, Sylo, Taml, Telu, Tibt, Thaa, Wara]
   Cyrillic: [Cyrl]
   CJK: [Hans, Hant, Kana, Kore, Jpan, Yiii]
   SouthEastAsian: [Bali, Batk, Bugi, Java, Khmr, Laoo, Mymr, Thai]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -3355,6 +3355,23 @@
             ],
             "ܣܘܪܝܝܐ"
         ],
+        "syl": [
+            "Sylo",
+            [
+                "AS"
+            ],
+            "ꠍꠤꠟꠐꠤ"
+        ],
+        "syl-beng": [
+            "Beng",
+            [
+                "AS"
+            ],
+            "সিলেটি"
+        ],
+        "syl-sylo": [
+            "syl"
+        ],
         "sm": [
             "Latn",
             [
@@ -4177,6 +4194,7 @@
             "Orya",
             "Saur",
             "Sinh",
+            "Sylo",
             "Taml",
             "Telu",
             "Tibt",
@@ -4337,6 +4355,7 @@
         "BD": [
             "bn",
             "en",
+            "syl",
             "ccp",
             "my",
             "mni"
@@ -4720,6 +4739,7 @@
             "bn",
             "zh-hant",
             "zh",
+            "syl",
             "el",
             "it",
             "ks-arab",


### PR DESCRIPTION
Making Sylo the default, because that's the only one used at translatewiki and Wikimedia Incubator.