### PR TITLE
Add changelog and release schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+Documentation can be found [here](https://language-data.readthedocs.io/en/latest/). Changelog is divided into the following,
+
+- [Language updates](#language-updates)
+- [PHP](#php)
+- [Node.js](#nodejs)
+
+## Language updates
+### 2020-05-20
+Language data related changes,
+1. [Add shy-latn and szy](https://github.com/wikimedia/language-data/pull/76)
+2. [Add Chukchi (ckt)](https://github.com/wikimedia/language-data/pull/78)
+3. [Fix autonym for Kildin Sami (sjd)](https://github.com/wikimedia/language-data/pull/90)
+4. [Change spelling of Innu-aimun autonym](https://github.com/wikimedia/language-data/pull/93)
+5. [Add Sylheti ](https://github.com/wikimedia/language-data/pull/94)
+6. [Split ary to ary-latn and ary-arab](https://github.com/wikimedia/language-data/pull/92)
+7. [Add Middle East and Africa to relevant Arabic varieties](https://github.com/wikimedia/language-data/pull/92)
+8. [Add Mongolian in vertical script ](https://github.com/wikimedia/language-data/pull/95)
+9. [Add AM as a region for Venetian](https://github.com/wikimedia/language-data/pull/96)
+
+## PHP
+### PHP 1.0.0 (2020-05-20)
+- See [language updates 2020-05-20](#2020-05-20).
+- Add PHP support. Documentation is [here](https://language-data.readthedocs.io/en/latest/api/languagedata/languageutil.html). Packagist is [here](https://example.com).
+
+## Node.js
+### Node.js 0.2.0 (2020-05-20)
+- See [language updates 2020-05-20](#2020-05-20).
+- Fix `npm audit` warnings.
+- Update minimum supported Node.js version to 8.0.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Language data related changes,
 ## PHP
 ### PHP 1.0.0 (2020-05-20)
 - See [language updates 2020-05-20](#2020-05-20).
-- Add PHP support. Documentation is [here](https://language-data.readthedocs.io/en/latest/api/languagedata/languageutil.html). Packagist is [here](https://example.com).
+- Add PHP support. [Documentation](https://language-data.readthedocs.io/en/latest/api/languagedata/languageutil.html). [Packagist](https://packagist.org/packages/wikimedia/language-data).
 
 ## Node.js
 ### Node.js 0.2.0 (2020-05-20)

--- a/README.md
+++ b/README.md
@@ -33,3 +33,11 @@ This data is populated from the current version of
 [node-build-url]: https://github.com/wikimedia/language-data/actions?query=workflow%3A%22Node.js+build%22
 [php-build]: https://github.com/wikimedia/language-data/workflows/PHP%20build/badge.svg
 [php-build-url]: https://github.com/wikimedia/language-data/actions?query=workflow%3A%22PHP+build%22
+
+## Release schedule
+Similar to [MLEB](https://www.mediawiki.org/wiki/MediaWiki_Language_Extension_Bundle), this library
+will have a quarterly release schedule, and will be released along with MLEB. Intermediate releases
+will be made incase a major bug is identified.
+
+## Changelog
+The full changelog is available [here](https://github.com/wikimedia/language-data/blob/master/CHANGELOG.md).

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This data is populated from the current version of
 ## Release schedule
 Similar to [MLEB](https://www.mediawiki.org/wiki/MediaWiki_Language_Extension_Bundle), this library
 will have a quarterly release schedule, and will be released along with MLEB. Intermediate releases
-will be made incase a major bug is identified.
+will be made for important bug fixes.
 
 ## Changelog
-The full changelog is available [here](https://github.com/wikimedia/language-data/blob/master/CHANGELOG.md).
+The full changelog is available in [CHANGELOG.md](https://github.com/wikimedia/language-data/blob/master/CHANGELOG.md).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -84,6 +84,10 @@ The basic usage is like this:
 
 The exposed methods are similar to the methods present in the PHP `LanguageUtil <api/languagedata/languageutil.html>`_ class.
 
+Changelog
+----------
+The full changelog is available `here <https://github.com/wikimedia/language-data/blob/master/CHANGELOG.md>`_.
+
 Contribute
 ----------
 


### PR DESCRIPTION
Divide the changelog into - Language updates, PHP and Node.js section

PHP and Node.js changelog will list library related changes and will
reuse Language updates section.

Add the release schedule to the README file.

Bug: T218639