### PR TITLE
Add Madurese (mad)

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -353,6 +353,7 @@ languages:
   lzh: [Hant, [AS], 文言]
  # Also Geor, but the incubator is in Latn
   lzz: [Latn, [EU, ME], Lazuri]
+  mad: [Latn, [AS], madhurâ]
   mai: [Deva, [AS], मैथिली]
   map-bms: [Latn, [AS], Basa Banyumasan]
   mdf: [Cyrl, [EU], мокшень]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -2250,6 +2250,13 @@
             ],
             "Lazuri"
         ],
+        "mad": [
+            "Latn",
+            [
+                "AS"
+            ],
+            "madhurâ"
+        ],
         "mai": [
             "Deva",
             [
@@ -4898,6 +4905,7 @@
             "id",
             "jv",
             "su",
+            "mad",
             "ms",
             "min",
             "bew",


### PR DESCRIPTION
This is needed for better support of the Wikipedia Incubator
( https://incubator.wikimedia.org/wiki/Wp/mad )
and translatewiki.

Autonym spelling according to this dictionary:
Adrian Pawitra, "Kamus lengkap bahasa madura—indonesia"
(The title is in Indonesian and hence spelled differently.)