### PR TITLE
Change Madurese autonym to capital

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -353,7 +353,7 @@ languages:
   lzh: [Hant, [AS], 文言]
  # Also Geor, but the incubator is in Latn
   lzz: [Latn, [EU, ME], Lazuri]
-  mad: [Latn, [AS], madhurâ]
+  mad: [Latn, [AS], Madhurâ]
   mai: [Deva, [AS], मैथिली]
   map-bms: [Latn, [AS], Basa Banyumasan]
   mdf: [Cyrl, [EU], мокшень]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -2255,7 +2255,7 @@
             [
                 "AS"
             ],
-            "madhurâ"
+            "Madhurâ"
         ],
         "mai": [
             "Deva",


### PR DESCRIPTION
According to "Pedoman Umum Ejaan Bahasa Madura yang Disempurnakan" (2008, page 8),
names of languages are supposed to be written with capital letters.

Online book:
http://repositori.kemdikbud.go.id/1761/1/Ejaan%20Bahasa%20Madura%20Yang%20Disempurnakan%20%282008%29.pdf