### PR TITLE
Bump minimum Node.js version to 10.x

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-v: [8.x, 10.x, 12.x]
+        node-v: [10.x, 12.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "url": "http://github.com/wikimedia/language-data/issues"
   },
   "engine": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "license": "GPL-2.0-or-later",
   "scripts": {


### PR DESCRIPTION
In a subsequent patch #120, we bump eslint-config-wikimedia to
0.17.0, which also requires bumping eslint to 7.9.0 which drops
support for Node.js 8.x

Bug: T266462