### PR TITLE
Update Min Dong Chinese languages

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -101,7 +101,10 @@ languages:
   cbk: [Latn, [AS], Chavacano de Zamboanga]
   cbk-zam: [cbk]
   ccp: [Cakm, [AS], 𑄌𑄋𑄴𑄟𑄳𑄦]
+ # FIXME cdo will be modified later to split to Latin and Chinese more cleanly
   cdo: [Latn, [AS], Mìng-dĕ̤ng-ngṳ̄]
+  cdo-latn: [Latn, [AS], Mìng-dĕ̤ng-ngṳ̄ Bàng-uâ-cê]
+  cdo-hani: [Hani, [AS], 閩東語漢字]
   ce: [Cyrl, [EU], нохчийн]
   ceb: [Latn, [AS], Cebuano]
   ch: [Latn, [PA], Chamoru]
@@ -651,6 +654,7 @@ languages:
   zh-sg: [Hans, [AS], 中文（新加坡）]
   zh-tw: [Hant, [AS], 中文（台灣）]
   zh-yue: [yue]
+  zh-cdo: [cdo]
   zu: [Latn, [AF], isiZulu]
   zun: [Latn, [AM], "Shiwi'ma"]
 
@@ -690,7 +694,7 @@ scriptgroups:
  # the Brahmic family.
   SouthAsian: [Beng, Cakm, Deva, Gujr, Guru, Knda, Mlym, Mtei, Olck, Orya, Saur, Sinh, Sylo, Taml, Telu, Tibt, Thaa, Wara]
   Cyrillic: [Cyrl]
-  CJK: [Hans, Hant, Kana, Kore, Jpan, Yiii]
+  CJK: [Hani, Hans, Hant, Kana, Kore, Jpan, Yiii]
   SouthEastAsian: [Bali, Batk, Bugi, Java, Khmr, Laoo, Mymr, Thai]
   Mongolian: [Mong]
   SignWriting: [Sgnw]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -640,6 +640,20 @@
             ],
             "Mìng-dĕ̤ng-ngṳ̄"
         ],
+        "cdo-latn": [
+            "Latn",
+            [
+                "AS"
+            ],
+            "Mìng-dĕ̤ng-ngṳ̄ Bàng-uâ-cê"
+        ],
+        "cdo-hani": [
+            "Hani",
+            [
+                "AS"
+            ],
+            "閩東語漢字"
+        ],
         "ce": [
             "Cyrl",
             [
@@ -4223,6 +4237,9 @@
         "zh-yue": [
             "yue"
         ],
+        "zh-cdo": [
+            "cdo"
+        ],
         "zu": [
             "Latn",
             [
@@ -4288,6 +4305,7 @@
             "Cyrl"
         ],
         "CJK": [
+            "Hani",
             "Hans",
             "Hant",
             "Kana",
@@ -5332,7 +5350,6 @@
         "MY": [
             "ms",
             "en",
-            "zh-hant",
             "zh",
             "ta",
             "jv",


### PR DESCRIPTION
Originally written by yjfvictor at
https://github.com/wikimedia/language-data/pull/58

Updated more conservatively by Amir E. Aharoni.
This is probably a transition to allow the splitting
to two variants. "cdo" will be reconfigured later
once the transition in other MediaWiki-related
properties will be over.