### PR TITLE
Add a simple test for validity of language codes

### DIFF
--- a/tests/js/index.js
+++ b/tests/js/index.js
@@ -2,7 +2,8 @@ var languageData = require( __dirname + '/../../src/index' ),
 	assert = require( 'assert' );
 
 describe( 'languagedata', function () {
-	var orphanScripts, badRedirects, doubleRedirects, doubleAutonyms, languagesWithoutAutonym;
+	var orphanScripts, badRedirects, invalidCodes,
+		doubleRedirects, doubleAutonyms, languagesWithoutAutonym;
 	/*
 	 * Runs over all script codes mentioned in langdb and checks whether
 	 * they belong to the 'Other' group.

--- a/tests/js/index.js
+++ b/tests/js/index.js
@@ -33,6 +33,22 @@ describe( 'languagedata', function () {
 		return result;
 	};
 	/*
+	 * Runs over all languages and checks that all redirects have a valid target.
+	 */
+	invalidCodes = function () {
+		var languageCode,
+			invalidCharsRe = /[^0-9a-z-]/,
+			result = [];
+
+		for ( languageCode in languageData.getLanguages() ) {
+			if ( languageCode.match( invalidCharsRe ) ) {
+				result.push( languageCode );
+			}
+		}
+
+		return result;
+	};
+	/*
 	 * Runs over all languages and checks that all redirects point to a language.
 	 * There's no reason to have double redirects.
 	 */
@@ -89,6 +105,7 @@ describe( 'languagedata', function () {
 	it( 'language tags', function () {
 		assert.ok( languageData.isKnown( 'ar' ), 'Language is unknown' );
 		assert.ok( !languageData.isKnown( 'unknownLanguageCode!' ), 'Language is known' );
+		assert.deepEqual( invalidCodes(), [], 'All language codes have no invalid characters.' );
 	} );
 
 	it( 'autonyms', function () {


### PR DESCRIPTION
The reason I'm adding it is that recently I almost submitted
a patch in which I wrote a language code with the Cyrillic letter о
instead of the corresponding Latin letter. It's not a perfect test,
but it's good enough for a basic check.