### PR TITLE
Fix PHP builds

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php: [7.4, 8.0]
+        php: [7.4]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -15,7 +15,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: ${{ matrix.php }}
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-interaction --ansi
@@ -24,4 +24,4 @@ jobs:
         run: composer run-script cs
 
       - name: Run tests
-        run: php${{ matrix.php }} ./vendor/bin/phpunit
+        run: php ./vendor/bin/phpunit

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -4,13 +4,18 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php: [7.2, 7.3]
+        php: [7.4, 8.0]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-interaction --ansi


### PR DESCRIPTION
Pin image to specific version so that we don't get surprise failures down the line.

Use common action to configure the default PHP version. The matrix versions only affected test running. Now it affects everything.

Only use PHP 7.4 as 8.0 does not pass.