### PR TITLE
Update the autonym of language shi

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -520,7 +520,7 @@ languages:
   sg: [Latn, [AF], Sängö]
   sgs: [Latn, [EU], žemaitėška]
   sh: [Latn, [EU], srpskohrvatski]
-  shi-latn: [Latn, [AF], Tašlḥiyt]
+  shi-latn: [Latn, [AF], Taclḥit]
   shi-tfng: [Tfng, [AF], ⵜⴰⵛⵍⵃⵉⵜ]
   shi: [shi-latn]
   shn: [Mymr, [AS], လိၵ်ႈတႆး]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -3370,7 +3370,7 @@
             [
                 "AF"
             ],
-            "Tašlḥiyt"
+            "Taclḥit"
         ],
         "shi-tfng": [
             "Tfng",


### PR DESCRIPTION
This language is known in English as Shilha, Tashelhit,
Tachelhit, and also by some other names.

The most authoritative modern name in the language itself
is Taclḥit, with the letter c. It appears in the textbook
"Méthode de tachelhit, langue amazighe (berbère) du sud du Maroc"
by Abdallah El Mountassir and also in the online
"Dictionnaire Général de la Langue Amazighe Informatisé"
( https://tal.ircam.ma/dglai/lexieam.php ). It also directly
corresponds to the spelling in the Tifinagh script.

This change was requested by the localizers in translatewiki
and authors in the Wikipedia Incubator in this language.