### PR TITLE
Cleanup the data for the Talysh language

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -586,8 +586,8 @@ languages:
   tk: [Latn, [AS], Türkmençe]
   tkr: [Cyrl, [AS], ЦӀаӀхна миз]
   tl: [Latn, [AS], Tagalog]
- # A very complicated case. Names.php is Cyrl. In TWN they argue about Cyrl, Latn, and Arab. I can't find reliable external sources. --Amir
-  tly: [Cyrl, [EU, AS, ME], толышә зывон]
+  tly: [Latn, [EU, AS, ME], tolışi]
+  tly-cyrl: [Cyrl, [EU, AS, ME], толыши]
   tmr: [Hebr, [ME, EU, AM], ארמית בבלית]
   tn: [Latn, [AF], Setswana]
   to: [Latn, [PA], lea faka-Tonga]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -3799,13 +3799,22 @@
             "Tagalog"
         ],
         "tly": [
+            "Latn",
+            [
+                "EU",
+                "AS",
+                "ME"
+            ],
+            "tolışi"
+        ],
+        "tly-cyrl": [
             "Cyrl",
             [
                 "EU",
                 "AS",
                 "ME"
             ],
-            "толышә зывон"
+            "толыши"
         ],
         "tmr": [
             "Hebr",


### PR DESCRIPTION
In the years that have passed since I wrote a comment saying
that this language is "complicated", I found sources that clearly
show that the primary alphabet for this language now is Latin.
See https://en.wikipedia.org/wiki/Talysh_language#Scripts

MediaWiki's Names.php was updated, too.