### PR TITLE
Add Aruba Papiamento

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -452,6 +452,7 @@ languages:
   pag: [Latn, [AS], Pangasinan]
   pam: [Latn, [AS], Kapampangan]
   pap: [Latn, [AM], Papiamentu]
+  pap-aw: [Latn, [AM], Papiamento]
   pbb: [Latn, [AM], Nasa Yuwe]
   pcd: [Latn, [EU], Picard]
   pdc: [Latn, [EU, AM], Deitsch]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -2911,6 +2911,13 @@
             ],
             "Papiamentu"
         ],
+        "pap-aw": [
+            "Latn",
+            [
+                "AM"
+            ],
+            "Papiamento"
+        ],
         "pbb": [
             "Latn",
             [


### PR DESCRIPTION
Requested at
https://translatewiki.net/wiki/Support#Activate_new_language-code:_Papiamento_(pap-aw)_58665

The name "Papiamento" (with -o) is used in the standard Aruba
spelling, and the -o in the end in enough for speakers to recognize
as the Aruban variant.