### PR TITLE
Add Rohg to rtlscripts

### DIFF
--- a/data/language-data.json
+++ b/data/language-data.json
@@ -4406,6 +4406,7 @@
         "Hebr",
         "Syrc",
         "Nkoo",
+        "Rohg",
         "Thaa"
     ],
     "regiongroups": {


### PR DESCRIPTION
This is added automatically by `php ulsdata2json.php`.
It should have been added in #137, but for some reason wasn't.