### PR TITLE
Add a newline to the end of language-data.json

### DIFF
--- a/src/util/ulsdata2json.php
+++ b/src/util/ulsdata2json.php
@@ -107,7 +107,7 @@ foreach ( $parsedLangdb['territories'] as $territoryCode => $languages ) {
 }
 
 print "Writing JSON langdb...\n";
-$jsonVerbose = json_encode( $parsedLangdb, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE );
+$jsonVerbose = json_encode( $parsedLangdb, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE ) . "\n";
 // For making diff review easier.
 file_put_contents( DATA_DIRECTORY . '/language-data.json', $jsonVerbose );
 


### PR DESCRIPTION
This helps Git and Vim be less confused about diffs.
It somehow sometimes happens that a newline is added to
the end of language-data.json, but sometimes it is not added,
and then Git diff shows it as removed or added. This change
ensures that it's always added.