### PR TITLE
Update the autonym for guc

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -223,7 +223,7 @@ languages:
   grc: [Grek, [EU], Ἀρχαία ἑλληνικὴ]
   gsw: [Latn, [EU], Alemannisch]
   gu: [Gujr, [AS], ગુજરાતી]
-  guc: [Latn, [AM], Wayúu]
+  guc: [Latn, [AM], wayuunaiki]
   gum: [Latn, [AM], Namtrik]
   gur: [Latn, [AF], Gurenɛ]
   guw: [Latn, [AF], gungbe]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -1407,7 +1407,7 @@
             [
                 "AM"
             ],
-            "Wayúu"
+            "wayuunaiki"
         ],
         "gum": [
             "Latn",


### PR DESCRIPTION
The name "Wayúu" appeared a long time ago in translatewiki,
and it's unclear what is its source. All the sources that I can
find say that autonym is "wayuunaiki", for example Ethnologue and
Diccionario básico ilustrado wayuunaiki-español español-wayuunaiki
(Editorial Fundación para el Desarrollo de los Pueblos Marginados, Bogotá, D.C., 2005)