### PR TITLE
Add Belizean Creole (bzj)

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -96,6 +96,7 @@ languages:
   bug: [Bugi, [AS], ᨅᨔ ᨕᨘᨁᨗ]
   bxr: [Cyrl, [AS], буряад]
   byn: [Ethi, [AF], ብሊን]
+  bzj: [Latn, [AM], Bileez Kriol]
   ca: [Latn, [EU], català]
   cak: [Latn, [AM], Kaqchikel]
   cbk: [Latn, [AS], Chavacano de Zamboanga]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -602,6 +602,13 @@
             ],
             "ብሊን"
         ],
+        "bzj": [
+            "Latn",
+            [
+                "AM"
+            ],
+            "Bileez Kriol"
+        ],
         "ca": [
             "Latn",
             [


### PR DESCRIPTION
Requested at
https://translatewiki.net/wiki/Thread:Template_talk:Disabled_language/Enabling_Belizean_Creole