### PR TITLE
Add the Basaa language (bas)

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -58,6 +58,7 @@ languages:
  # For support in webfonts.
   ban-bali: [Bali, [AS, PA], ᬩᬮᬶ]
   bar: [Latn, [EU], Boarisch]
+  bas: [Latn, [AF], ɓasaá]
   bat-smg: [sgs]
   bbc-latn: [Latn, [AS], Batak Toba]
   bbc-batk: [Batk, [AS], ᯅᯖᯂ᯲ ᯖᯬᯅ]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -355,6 +355,13 @@
             ],
             "Boarisch"
         ],
+        "bas": [
+            "Latn",
+            [
+                "AF"
+            ],
+            "ɓasaá"
+        ],
         "bat-smg": [
             "sgs"
         ],
@@ -4705,6 +4712,7 @@
             "fr",
             "en",
             "ff",
+            "bas",
             "ar",
             "ksf",
             "ha-arab",


### PR DESCRIPTION
Requested at
https://translatewiki.net/wiki/Thread:Talk:Support/Ajouter_la_langue_bassa%27a

Autonym according to
Hyman, Larry M. (2003). "Basaá (A.43)".
In Nurse, Derek; Philippson, Gérard (eds.).
The Bantu Languages. Routledge. pp. 257–282.