### PR TITLE
Add the Kom language (bkm)

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -81,6 +81,7 @@ languages:
   bho: [Deva, [AS], भोजपुरी]
   bi: [Latn, [PA], Bislama]
   bjn: [Latn, [AS], Banjar]
+  bkm: [Latn, [AF], Itaŋikom]
   blc: [Latn, [AM], ItNuxalkmc]
   bm: [Latn, [AF], bamanankan]
   bn: [Beng, [AS], বাংলা]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -495,6 +495,13 @@
             ],
             "Banjar"
         ],
+        "bkm": [
+            "Latn",
+            [
+                "AF"
+            ],
+            "Itaŋikom"
+        ],
         "blc": [
             "Latn",
             [
@@ -4719,6 +4726,7 @@
             "fr",
             "en",
             "ff",
+            "bkm",
             "bas",
             "ar",
             "ksf",


### PR DESCRIPTION
Requested at
https://translatewiki.net/wiki/Thread:Support/Please_add_the_Kom_language

Autonym as used in the introduction to
Provisional Kom - English Lexicon by Randy Jones (2001),
and confirmed by a native speaker.