### PR TITLE
Add the Dargin (Dargwa) language (dar)

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -149,6 +149,7 @@ languages:
   cy: [Latn, [EU], Cymraeg]
   da: [Latn, [EU], dansk]
   dag: [Latn, [AF], dagbanli]
+  dar: [Cyrl, [EU], дарган]
   de-at: [Latn, [EU], Österreichisches Deutsch]
   de-ch: [Latn, [EU], Schweizer Hochdeutsch]
   de-formal: [Latn, [EU], Deutsch (Sie-Form)]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -894,6 +894,13 @@
             ],
             "dagbanli"
         ],
+        "dar": [
+            "Cyrl",
+            [
+                "EU"
+            ],
+            "дарган"
+        ],
         "de-at": [
             "Latn",
             [
@@ -5705,6 +5712,7 @@
             "os",
             "kbd",
             "myv",
+            "dar",
             "mdf",
             "kum",
             "kv",


### PR DESCRIPTION
Requested at
https://translatewiki.net/wiki/Thread:Support/Dargin_language

Autonym according to:
Х.ГӀ. Юсупов, «Даргала-урусла словарь», ХӀ. ЦӀадасала уличилси
Мезла, литературала ва искусствола институт, МяхIячкъала 2014
and verified with speakers.