### PR TITLE
Make 'ha' the primary code for Hausa

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -232,10 +232,11 @@ languages:
   gur: [Latn, [AF], Gurenɛ]
   guw: [Latn, [AF], gungbe]
   gv: [Latn, [EU], Gaelg]
- # CLDR uses ha-latn and ha-arab. Latin is more common and is used in Wikipedia.
+ # CLDR uses ha for Latin script and ha-arab for Arabic script.
+ # Latin is more common and is used in Wikipedia.
+  ha: [Latn, [AF], Hausa]
   ha-arab: [Arab, [AF], هَوُسَ]
-  ha-latn: [Latn, [AF], Hausa]
-  ha: [ha-latn]
+  ha-latn: [ha]
   hai: [Latn, [AM], X̱aat Kíl]
   hak: [Latn, [AS], Hak-kâ-fa]
   haw: [Latn, [AM, PA], Hawai`i]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -1465,6 +1465,13 @@
             ],
             "Gaelg"
         ],
+        "ha": [
+            "Latn",
+            [
+                "AF"
+            ],
+            "Hausa"
+        ],
         "ha-arab": [
             "Arab",
             [
@@ -1473,14 +1480,7 @@
             "هَوُسَ"
         ],
         "ha-latn": [
-            "Latn",
-            [
-                "AF"
-            ],
-            "Hausa"
-        ],
-        "ha": [
-            "ha-latn"
+            "ha"
         ],
         "hai": [
             "Latn",
@@ -4745,7 +4745,7 @@
             "ar",
             "ksf",
             "ha-arab",
-            "ha-latn"
+            "ha"
         ],
         "CN": [
             "zh",
@@ -5011,7 +5011,7 @@
             "ee",
             "gur",
             "gaa",
-            "ha-latn",
+            "ha",
             "ff"
         ],
         "GI": [
@@ -5510,7 +5510,7 @@
             "fr"
         ],
         "NE": [
-            "ha-latn",
+            "ha",
             "fr",
             "ar",
             "ff"
@@ -5520,7 +5520,7 @@
         ],
         "NG": [
             "en",
-            "ha-latn",
+            "ha",
             "ig",
             "yo",
             "ha-arab",
@@ -5763,7 +5763,7 @@
             "ar",
             "en",
             "ha-arab",
-            "ha-latn"
+            "ha"
         ],
         "SE": [
             "sv",


### PR DESCRIPTION
Will hopefully address these downstream bugs:
https://phabricator.wikimedia.org/T279269
https://phabricator.wikimedia.org/T279252