### PR TITLE
Add the Paiwan language (pwn)

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -482,6 +482,7 @@ languages:
   ps: [Arab, [AS, ME], پښتو]
   pt-br: [Latn, [AM], português do Brasil]
   pt: [Latn, [EU, AM, AS, PA, AF, WW], português]
+  pwn: [Latn, [AS], pinayuanan]
   qu: [Latn, [AM], Runa Simi]
   quc: [Latn, [AM], "K'iche'"]
   qug: [Latn, [AM], Runa shimi]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -3124,6 +3124,13 @@
             ],
             "português"
         ],
+        "pwn": [
+            "Latn",
+            [
+                "AS"
+            ],
+            "pinayuanan"
+        ],
         "qu": [
             "Latn",
             [


### PR DESCRIPTION
Requested at
https://translatewiki.net/wiki/Thread:Support/_Wp/pwn_Translation_of_MediaWiki_(most_important_messages)

Autonym verified with Paiwan dictionary by Raliegh Ferrell
( https://archive.org/details/paiwandictionary0000ferr )
and the online dictionary on the website of Taiwan's
Council of Indigenous People
( https://e-dictionary.apc.gov.tw/pwn/search.htm ).
It's also confirmed at
https://incubator.wikimedia.org/w/index.php?oldid=5144344#The_name_of_the_Paiwan_language_in_itself