### PR TITLE
Add Rohingya as a language of Bangladesh and Burma

### DIFF
--- a/data/language-data.json
+++ b/data/language-data.json
@@ -4587,6 +4587,7 @@
             "bn",
             "en",
             "syl",
+            "rhg",
             "ccp",
             "my",
             "mni"
@@ -5417,6 +5418,7 @@
             "my",
             "shn",
             "kac",
+            "rhg",
             "mnw"
         ],
         "MN": [


### PR DESCRIPTION
It was added to Language-Territory information in CLDR 39,
and automatically added here by the updating script.