### PR TITLE
Rename gur to "farefare"

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -233,7 +233,7 @@ languages:
   gu: [Gujr, [AS], ગુજરાતી]
   guc: [Latn, [AM], wayuunaiki]
   gum: [Latn, [AM], Namtrik]
-  gur: [Latn, [AF], Gurenɛ]
+  gur: [Latn, [AF], farefare]
   guw: [Latn, [AF], gungbe]
   gv: [Latn, [EU], Gaelg]
  # CLDR uses ha for Latin script and ha-arab for Arabic script.

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -1473,7 +1473,7 @@
             [
                 "AF"
             ],
-            "Gurenɛ"
+            "farefare"
         ],
         "guw": [
             "Latn",


### PR DESCRIPTION
The name "gurenɛ" is used only in Ghana and refers only
to one dialect. This language is also spoken in Burkina Faso,
and the name "farefare" covers all the dialects in both
countries. The activity in this language in translatewiki.net
and in the Wikimedia Incubator is higher recently, and this
was requested by the contributors to this language.

Confirmed with the book
De  la  phonologie à l’orthographe : Le ninkãrɛ au Burkina Faso,
Idda et Urs Niggli SIL, 2007
(page 6).