### PR TITLE
Update Toki Pona

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -623,6 +623,7 @@ languages:
   tn: [Latn, [AF], Setswana]
   to: [Latn, [PA], lea faka-Tonga]
   tok: [Latn, [WW], toki pona]
+  tokipona: [tok]
   tpi: [Latn, [PA, AS], Tok Pisin]
   tr: [Latn, [EU, ME], Türkçe]
   trp: [Latn, [AS], Kokborok (Tripuri)]

--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -622,7 +622,7 @@ languages:
   tmr: [Hebr, [ME, EU, AM], ארמית בבלית]
   tn: [Latn, [AF], Setswana]
   to: [Latn, [PA], lea faka-Tonga]
-  tokipona: [Latn, [WW], Toki Pona]
+  tok: [Latn, [WW], toki pona]
   tpi: [Latn, [PA, AS], Tok Pisin]
   tr: [Latn, [EU, ME], Türkçe]
   trp: [Latn, [AS], Kokborok (Tripuri)]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -4051,6 +4051,9 @@
             ],
             "toki pona"
         ],
+        "tokipona": [
+            "tok"
+        ],
         "tpi": [
             "Latn",
             [

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -4044,12 +4044,12 @@
             ],
             "lea faka-Tonga"
         ],
-        "tokipona": [
+        "tok": [
             "Latn",
             [
                 "WW"
             ],
-            "Toki Pona"
+            "toki pona"
         ],
         "tpi": [
             "Latn",


### PR DESCRIPTION
The code `tokipona` is not a valid ISO code. This week Toki Pona received a valid ISO code: `tok`. This can be verified [here](https://iso639-3.sil.org/code/tok) and [here](https://iso639-3.sil.org/request/2021-043). This pull request changes `tokipona` to `tok`.

The correct autonym for Toki Pona is `toki pona`. In Toki Pona, all native words are written in lowercase. Check [page 3 of the ISO request](https://iso639-3.sil.org/sites/iso639-3/files/change_requests/2021/2021-043_tok.pdf#page=3) for a source.