### PR TITLE
Fix the autonym for Rundi (rn)

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -519,7 +519,7 @@ languages:
  # Also known as Fíntika Rómma
   rmf: [Latn, [EU], kaalengo tšimb]
   rmy: [Latn, [EU], Romani]
-  rn: [Latn, [AF], Kirundi]
+  rn: [Latn, [AF], ikirundi]
   ro: [Latn, [EU], română]
   roa-rup: [rup]
   roa-tara: [Latn, [EU], tarandíne]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -3381,7 +3381,7 @@
             [
                 "AF"
             ],
-            "Kirundi"
+            "ikirundi"
         ],
         "ro": [
             "Latn",


### PR DESCRIPTION
The name "Kirundi" was added to MediaWiki very early in
its history. This name is used in English (in addition to "Rundi"),
but the native name is actually "ikirundi". It appears in Ethnologue.

See also
https://phabricator.wikimedia.org/T302972