### PR TITLE
Fix the geo data of Karay-a (krj)

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -339,7 +339,7 @@ languages:
   kr: [Latn, [AF], Kanuri]
   krc: [Cyrl, [EU], къарачай-малкъар]
   kri: [Latn, [AF], Krio]
-  krj: [Latn, [ME, EU], Kinaray-a]
+  krj: [Latn, [AS], Kinaray-a]
   krl: [Latn, [EU], Karjala]
   ks-arab: [Arab, [AS], کٲشُر]
   ks-deva: [Deva, [AS], कॉशुर]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -2153,8 +2153,7 @@
         "krj": [
             "Latn",
             [
-                "ME",
-                "EU"
+                "AS"
             ],
             "Kinaray-a"
         ],


### PR DESCRIPTION
It has been mistakenly defined as "ME, EU" since langdb was created.