### PR TITLE
Redirect "Eastern Yiddish" (ydd) to Yiddish (yi)

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -681,7 +681,7 @@ languages:
   xh: [Latn, [AF], isiXhosa]
   xmf: [Geor, [EU], მარგალური]
   xsy: [Latn, [AS], SaiSiyat]
-  ydd: [Hebr, [AS, EU], Eastern Yiddish]
+  ydd: [yi]
   yi: [Hebr, [ME, EU, AM], ייִדיש]
   yo: [Latn, [AF], Yorùbá]
   yrk: [Cyrl, [AS], ненэцяʼ вада]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -4431,12 +4431,7 @@
             "SaiSiyat"
         ],
         "ydd": [
-            "Hebr",
-            [
-                "AS",
-                "EU"
-            ],
-            "Eastern Yiddish"
+            "yi"
         ],
         "yi": [
             "Hebr",


### PR DESCRIPTION
"Eastern" Yiddish is much more common than Western, so ydd
and yi refer to the same language. It's unclear why was ydd
even added to translatewiki. It was done very long ago,
before translatewiki configuration was managed in Git.
There are no translation into it there, which makes sense,
given that it's the same as just Yiddish (yi).

Given that ydd is a standard code, it can remain as
a redirect, but it shouldn't really be used.