### PR TITLE
Remove Livvi Karelian from Asia

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -465,7 +465,7 @@ languages:
   oc: [Latn, [EU], occitan]
   ojb: [Latn, [AM], Ojibwemowin]
   oka: [Latn, [AM], n̓səl̓xcin̓]
-  olo: [Latn, [AS, EU], livvinkarjala]
+  olo: [Latn, [EU], livvinkarjala]
   om: [Latn, [AF], Oromoo]
   ood: [Latn, [AM], "ʼOʼodham ha-ñeʼokĭ"]
   or: [Orya, [AS], ଓଡ଼ିଆ]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -3004,7 +3004,6 @@
         "olo": [
             "Latn",
             [
-                "AS",
                 "EU"
             ],
             "livvinkarjala"


### PR DESCRIPTION
It was there by mistake. It's definitely just in Europe.