### PR TITLE
Update Kinyarwanda autonym

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -536,7 +536,7 @@ languages:
   ruq-grek: [Grek, [EU], Megleno-Romanian (Greek script)]
   ruq-latn: [Latn, [EU], Vlăheşte]
   rut: [Cyrl, [EU], мыхаӀбишды]
-  rw: [Latn, [AF], Kinyarwanda]
+  rw: [Latn, [AF], Ikinyarwanda]
  # Bug: 60815
   rwr: [Deva, [AS], मारवाड़ी]
   ryu: [Kana, [AS], ʔucināguci]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -3478,7 +3478,7 @@
             [
                 "AF"
             ],
-            "Kinyarwanda"
+            "Ikinyarwanda"
         ],
         "rwr": [
             "Deva",


### PR DESCRIPTION
Correct it to be the same as in MediaWiki core.
Spelling verified in
Iriza Kinyarwanda Engish And English Kinyarwanda Dictionary.