### PR TITLE
Rename Orya to Odia

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -464,7 +464,7 @@ languages:
   olo: [Latn, [EU], livvinkarjala]
   om: [Latn, [AF], Oromoo]
   ood: [Latn, [AM], "ʼOʼodham ha-ñeʼokĭ"]
-  or: [Orya, [AS], ଓଡ଼ିଆ]
+  or: [Odia, [AS], ଓଡ଼ିଆ]
   os: [Cyrl, [EU], ирон]
   osi: [Latn, [AS], Using]
   ota: [Arab, [AS, EU], لسان عثمانى]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -3023,7 +3023,7 @@
             "ʼOʼodham ha-ñeʼokĭ"
         ],
         "or": [
-            "Orya",
+            "Odia",
             [
                 "AS"
             ],


### PR DESCRIPTION
See:
* https://en.wikipedia.org/wiki/Odia_language
* https://www.hindustantimes.com/delhi/constitution-amended-orissa-is-odisha-oriya-is-odia/story-ueHHnEL8pOLbup8JuT1UOP.html