### PR TITLE
Change Kanuri autonym to lowercase

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -332,7 +332,7 @@ languages:
   ko: [Kore, [AS], 한국어]
   koi: [Cyrl, [EU], перем коми]
   koy: [Latn, [AM], "Denaakkenaageʼ"]
-  kr: [Latn, [AF], Kanuri]
+  kr: [Latn, [AF], kanuri]
   krc: [Cyrl, [EU], къарачай-малкъар]
   kri: [Latn, [AF], Krio]
   krj: [Latn, [AS], Kinaray-a]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -2134,7 +2134,7 @@
             [
                 "AF"
             ],
-            "Kanuri"
+            "kanuri"
         ],
         "krc": [
             "Cyrl",


### PR DESCRIPTION
In Kanuri, the name of the language is specifically
written in lowercase, according to
"Dictionary of the Kanuri Language"
Edited by: Norbert Cyffer and John Hutchinson
De Gruyter 1990.