### PR TITLE
Add Makassarese (mak)

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -387,6 +387,8 @@ languages:
   lzz: [Latn, [EU, ME], Lazuri]
   mad: [Latn, [AS], Madhurâ]
   mai: [Deva, [AS], मैथिली]
+  mak: [Latn, [AS, PA], Mangkasarak]
+  mak-bugi: [Bugi, [AS, PA], ᨆᨀᨔᨑ]
   map-bms: [Latn, [AS], Basa Banyumasan]
   mcn: [Latn, [AF], vùn màsànà]
   mdf: [Cyrl, [EU], мокшень]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -2497,6 +2497,22 @@
             ],
             "मैथिली"
         ],
+        "mak": [
+            "Latn",
+            [
+                "AS",
+                "PA"
+            ],
+            "Mangkasarak"
+        ],
+        "mak-bugi": [
+            "Bugi",
+            [
+                "AS",
+                "PA"
+            ],
+            "ᨆᨀᨔᨑ"
+        ],
         "map-bms": [
             "Latn",
             [
@@ -5422,6 +5438,7 @@
             "bbc-latn",
             "zh-hant",
             "zh",
+            "mak",
             "rej",
             "gor",
             "sly",


### PR DESCRIPTION
Requested at
https://translatewiki.net/wiki/Thread:Support/Request_to_reactivate_Makassarese_to_Translatewiki

Autonyms in Latin and Lontara script according
to page 187 in this dictionary:
Kamus Makassar-Indonesia, Drs. Aburaerah Arief, 1995

Comment: It appears that there are two spelling standards.
In the other one, the name is written with an apostrophe
instead of the letter k in the end. The one with k appears to be
the common one in Indonesian publications, and is
used in the Wikimedia Incubator. If the speakers' community
ever decides to move the spelling with the apostrophe,
the name can be changed.