### PR TITLE
Fix Hawaiian (haw) autonym

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -254,7 +254,7 @@ languages:
   ha-latn: [ha]
   hai: [Latn, [AM], X̱aat Kíl]
   hak: [Latn, [AS], Hak-kâ-fa]
-  haw: [Latn, [AM, PA], Hawai`i]
+  haw: [Latn, [AM, PA], Hawaiʻi]
   he: [Hebr, [ME], עברית]
   hak-hans: [Hans, [AS], 客家语（简体）]
   hak-hant: [Hant, [AS], 客家語（繁體）]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -1618,7 +1618,7 @@
                 "AM",
                 "PA"
             ],
-            "Hawai`i"
+            "Hawaiʻi"
         ],
         "he": [
             "Hebr",


### PR DESCRIPTION
The apostrophe-like character in the name is a letter called ʻokina [1].

[1] https://en.wikipedia.org/wiki/ʻOkina