### PR TITLE
Add Jèrriais (nrf-je) and Guernésiais (nrf-gg)

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -468,6 +468,8 @@ languages:
   nov: [Latn, [WW], Novial]
   nqo: [Nkoo, [AF], ߒߞߏ]
   nr: [Latn, [AF], isiNdebele seSewula]
+  nrf-gg: [Latn, [EU], Guernésiais]
+  nrf-je: [Latn, [EU], Jèrriais]
   nrm: [Latn, [EU], Nouormand]
   nso: [Latn, [AF], Sesotho sa Leboa]
   nus: [Latn, [AF], Thok Naath]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -3052,6 +3052,20 @@
             ],
             "isiNdebele seSewula"
         ],
+        "nrf-gg": [
+            "Latn",
+            [
+                "EU"
+            ],
+            "Guernésiais"
+        ],
+        "nrf-je": [
+            "Latn",
+            [
+                "EU"
+            ],
+            "Jèrriais"
+        ],
         "nrm": [
             "Latn",
             [


### PR DESCRIPTION
In use in Wikidata for monolingual text [1] and lexemes [2]. For the autonym of Jèrriais, see [3] by the Société Jersiaise and the website Les Pages Jèrriaises [4]. For the autonym of Guernésiais, see [5] from gov.gg and [6] from BBC Guernsey. [7] from the Guernsey Language Commission, although in English, uses the same spelling.
Wikidata item for Jèrriais: https://www.wikidata.org/wiki/Q56430
Wikidata item for Guernésiais: https://www.wikidata.org/wiki/Q56428

[1] https://github.com/wikimedia/Wikibase/blob/425d9d47794b1e36a792be0180dd7f8d63bc6418/lib/includes/WikibaseContentLanguages.php#L144
[2] https://github.com/wikimedia/mediawiki-extensions-WikibaseLexeme/blob/548ead57fa89125962425efd6268d5c040353532/WikibaseLexeme.mediawiki-services.php#L27
[3] https://members.societe-jersiaise.org/sdllj/
[4] http://members.societe-jersiaise.org/geraint/jerriais.html
[5] https://www.gov.gg/article/188735/Oy-ous-Dvis-ous-lGuernsiais-Do-you-speak-Guernsey-French
[6] https://www.bbc.co.uk/guernsey/content/articles/2005/01/24/guernsey_french_learn_feature.shtml
[7] http://www.language.gg/