### PR TITLE
Add Monégasque (lij-mc)

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -370,6 +370,7 @@ languages:
   lg: [Latn, [AF], Luganda]
   li: [Latn, [EU], Limburgs]
   lij: [Latn, [EU], Ligure]
+  lij-mc: [Latn, [EU], munegascu]
   liv: [Latn, [EU], Līvõ kēļ]
   lki: [Arab, [AS, ME], لەکی]
   lkt: [Latn, [AM], Lakȟótiyapi]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -2382,6 +2382,13 @@
             ],
             "Ligure"
         ],
+        "lij-mc": [
+            "Latn",
+            [
+                "EU"
+            ],
+            "munegascu"
+        ],
         "liv": [
             "Latn",
             [


### PR DESCRIPTION
In use in Wikidata for monolingual text [1] and lexemes [2]. For the autonym, see Dictionnaire Français-Monégasque [3] by the Comité National des Tradtions Monégasques and a page about the language [4] by the Académie des Langues Dialectales (Monaco).
Wikidata item: https://www.wikidata.org/wiki/Q56422

[1] https://github.com/wikimedia/Wikibase/blob/425d9d47794b1e36a792be0180dd7f8d63bc6418/lib/includes/WikibaseContentLanguages.php#L144
[2] https://github.com/wikimedia/mediawiki-extensions-WikibaseLexeme/blob/548ead57fa89125962425efd6268d5c040353532/WikibaseLexeme.mediawiki-services.php#L27
[3] http://www.traditions-monaco.com/dictionnaire-francais-monegasque
[4] http://www.ald-monaco.org/langues-monegasque/la-langue-monegasque-son-origine-et-sa-typologie-6