### PR TITLE
Add Romansh variants

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -523,6 +523,12 @@ languages:
   rif: [Latn, [AF], Tarifit]
   rki: [Mymr, [AS], ရခိုင်]
   rm: [Latn, [EU], rumantsch]
+  rm-puter: [Latn, [EU], puter]
+  rm-rumgr: [Latn, [EU], rumantsch grischun]
+  rm-surmiran: [Latn, [EU], surmiran]
+  rm-sursilv: [Latn, [EU], sursilvan]
+  rm-sutsilv: [Latn, [EU], sutsilvan]
+  rm-vallader: [Latn, [EU], vallader]
   rmc: [Latn, [EU], romaňi čhib]
  # Also known as Fíntika Rómma
   rmf: [Latn, [EU], kaalengo tšimb]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -3446,6 +3446,48 @@
             ],
             "rumantsch"
         ],
+        "rm-puter": [
+            "Latn",
+            [
+                "EU"
+            ],
+            "puter"
+        ],
+        "rm-rumgr": [
+            "Latn",
+            [
+                "EU"
+            ],
+            "rumantsch grischun"
+        ],
+        "rm-surmiran": [
+            "Latn",
+            [
+                "EU"
+            ],
+            "surmiran"
+        ],
+        "rm-sursilv": [
+            "Latn",
+            [
+                "EU"
+            ],
+            "sursilvan"
+        ],
+        "rm-sutsilv": [
+            "Latn",
+            [
+                "EU"
+            ],
+            "sutsilvan"
+        ],
+        "rm-vallader": [
+            "Latn",
+            [
+                "EU"
+            ],
+            "vallader"
+        ],
         "rmc": [
             "Latn",
             [


### PR DESCRIPTION
In use in Wikidata for monolingual text [1] and lexemes [2].
For the autonyms, see [3], an online dictionary by the Lia Rumantscha, an umbrella organisation of Romansh language organisations and the dialects section of [4], an article about Romansh in e-LIR, which is a Romansh encyclopedia about the Romansh speaking area of Switzerland. Puter is sometimes written "putèr", as noted in [5], but all three sites just mentioned use "puter".

Wikidata items:
Puter: https://www.wikidata.org/wiki/Q688309
Rumantsch Grischun: https://www.wikidata.org/wiki/Q688873
Surmiran: https://www.wikidata.org/wiki/Q690216
Sursilvan: https://www.wikidata.org/wiki/Q688348
Sutsilvan: https://www.wikidata.org/wiki/Q688272
Vallader: https://www.wikidata.org/wiki/Q690226

[1] https://github.com/wikimedia/Wikibase/blob/425d9d47794b1e36a792be0180dd7f8d63bc6418/lib/includes/WikibaseContentLanguages.php#L144
[2] https://github.com/wikimedia/mediawiki-extensions-WikibaseLexeme/blob/548ead57fa89125962425efd6268d5c040353532/WikibaseLexeme.mediawiki-services.php#L27
[3] https://www.pledarigrond.ch/
[4] http://www.e-lir.ch/index.php?id=1440
[5] https://rm.wikipedia.org/wiki/Puter