### PR TITLE
Add Latin script for Manchu (mnc-latn)

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -469,6 +469,7 @@ languages:
   mn-cyrl: [mn]
   mn-mong: [mvf]
   mnc: [Mong, [AS], ᠮᠠᠨᠵᡠ ᡤᡳᠰᡠᠨ]
+  mnc-latn: [Latn, [AS], Manju gisun]
   mni: [Mtei, [AS], ꯃꯤꯇꯩ ꯂꯣꯟ]
   mni-beng: [Beng, [AS], মেইতেই লোন্]
   mnw: [Mymr, [AS], ဘာသာမန်]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -2921,6 +2921,13 @@
             ],
             "ᠮᠠᠨᠵᡠ ᡤᡳᠰᡠᠨ"
         ],
+        "mnc-latn": [
+            "Latn",
+            [
+                "AS"
+            ],
+            "Manju gisun"
+        ],
         "mni": [
             "Mtei",
             [


### PR DESCRIPTION
Manchu (mnc) should be added to Names.php [1] but the translations are a mixture of Latin and Mongolian scripts and need to be split [2]. For the autonym, see the existing translations [3] and the main page of the Manchu Wikipedia in the Incubator [4].

[1] https://phabricator.wikimedia.org/T284043
[2] https://phabricator.wikimedia.org/T318496
[3] https://translatewiki.net/w/i.php?search=%22manju+gisun%22&ns8=1&ns1206=1
[4] https://incubator.wikimedia.org/wiki/Wp/mnc/%E1%A1%A0%E1%A0%B5%E1%A1%A0%E1%A1%B3_%E1%A0%A0%E1%A1%B6%E1%A0%A0%E1%A1%A5%E1%A0%A0