### PR TITLE
Add American English (en-us)

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -185,6 +185,7 @@ languages:
   en-ca: [Latn, [AM], Canadian English]
   en-gb: [Latn, [EU, AS, PA], British English]
   en-simple: [Latn, [WW], Simple English]
+  en-us: [Latn, [AM], American English]
   en: [Latn, [EU, AM, AF, ME, AS, PA, WW], English]
   eo: [Latn, [WW], Esperanto]
   es-419: [Latn, [AM], español de América Latina]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -1146,6 +1146,13 @@
             ],
             "Simple English"
         ],
+        "en-us": [
+            "Latn",
+            [
+                "AM"
+            ],
+            "American English"
+        ],
         "en": [
             "Latn",
             [


### PR DESCRIPTION
In use in Wikidata for labels, monolingual text and lexemes [1].

[1] https://gerrit.wikimedia.org/r/plugins/gitiles/operations/mediawiki-config/+/f7c596ad7737cd266edffa7f6c20916436ce586e/wmf-config/InitialiseSettings.php#21869 (large page)