### PR TITLE
Add script variants for Serbo-Croatian (sh-cyrl and sh-latn)

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -634,6 +634,8 @@ languages:
   sg: [Latn, [AF], Sängö]
   sgs: [Latn, [EU], žemaitėška]
   sh: [Latn, [EU], srpskohrvatski]
+  sh-cyrl: [Cyrl, [EU], српскохрватски]
+  sh-latn: [sh]
   shi-latn: [Latn, [AF], Taclḥit]
   shi-tfng: [Tfng, [AF], ⵜⴰⵛⵍⵃⵉⵜ]
   shi: [shi-latn]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -3986,6 +3986,16 @@
             ],
             "srpskohrvatski"
         ],
+        "sh-cyrl": [
+            "Cyrl",
+            [
+                "EU"
+            ],
+            "српскохрватски"
+        ],
+        "sh-latn": [
+            "sh"
+        ],
         "shi-latn": [
             "Latn",
             [


### PR DESCRIPTION
Script variants for Serbo-Croatian have been added to Names.php [1] as part of the changes for adding a language converter [2].

[1] https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/core/+/a573bea01b7f05186324327cbcdf804644b863d2/includes/languages/data/Names.php#422
[2] https://phabricator.wikimedia.org/T268033