### PR TITLE
Update the autonym for Guadeloupean Creole (gcf)

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -252,7 +252,7 @@ languages:
   gaz: [om]
   gbm: [Deva, [AS], गढ़वळि]
   gbz: [Latn, [AS], Dari-e Mazdeyasnā]
-  gcf: [Latn, [AM], Guadeloupean Creole French]
+  gcf: [Latn, [AM], kréyòl Gwadloup]
   gcr: [Latn, [AM], kriyòl gwiyannen]
   gd: [Latn, [EU], Gàidhlig]
   gez: [Ethi, [AF], ግዕዝ]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -1520,7 +1520,7 @@
             [
                 "AM"
             ],
-            "Guadeloupean Creole French"
+            "kréyòl Gwadloup"
         ],
         "gcr": [
             "Latn",


### PR DESCRIPTION
The language was added long ago with an English name.

Source for the correct autonym:
https://apics-online.info/contributions/50