### PR TITLE
Add Brazilian Sign Language

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -121,6 +121,7 @@ languages:
   bxr: [Cyrl, [AS], буряад]
   byn: [Ethi, [AF], ብሊን]
   bzj: [Latn, [AM], Bileez Kriol]
+  bzs: [Sgnw, [AM], Língua brasileira de sinais]
   ca: [Latn, [EU], català]
   cak: [Latn, [AM], Kaqchikel]
   cbk: [Latn, [AS], Chavacano de Zamboanga]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -745,6 +745,13 @@
             ],
             "Bileez Kriol"
         ],
+        "bzs": [
+            "Sgnw",
+            [
+                "AM"
+            ],
+            "Língua brasileira de sinais"
+        ],
         "ca": [
             "Latn",
             [


### PR DESCRIPTION
Requested at
https://translatewiki.net/w/i.php?title=Support&oldid=11615943#Request_for_inclusion_of_Brazilian_Sign_Language

The name is written in Portuguese. This is similar to how it's done with American Sign Language (ase), which uses an English "autonym", and that's also what
was requested for the Brazilian Sign Language.