### PR TITLE
Add Bole (bol) and Karekare (kai)

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -106,6 +106,7 @@ languages:
   bn: [Beng, [AS], বাংলা]
   bnn: [Latn, [AS], bunun]
   bo: [Tibt, [AS], བོད་ཡིག]
+  bol: [Latn, [AF], bòo pìkkà]
   bom: [Latn, [AF], bèrom]
   bpy: [Beng, [AS], বিষ্ণুপ্রিয়া মণিপুরী]
   bqi: [Arab, [AS, ME], بختیاری]
@@ -344,6 +345,7 @@ languages:
  # Can also be Tfng, but the Wikipedia is mostly Latn
   kab: [Latn, [AF, EU], Taqbaylit]
   kac: [Latn, [AS], Jinghpaw]
+  kai: [Latn, [AF], Karai-karai]
   kam: [Latn, [AF], kĩkamba]
   kbd: [Cyrl, [EU, ME], адыгэбзэ]
   kbd-cyrl: [kbd]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -638,6 +638,13 @@
             ],
             "བོད་ཡིག"
         ],
+        "bol": [
+            "Latn",
+            [
+                "AF"
+            ],
+            "bòo pìkkà"
+        ],
         "bom": [
             "Latn",
             [
@@ -2114,6 +2121,13 @@
                 "AS"
             ],
             "Jinghpaw"
+        ],
+        "kai": [
+            "Latn",
+            [
+                "AF"
+            ],
+            "Karai-karai"
         ],
         "kam": [
             "Latn",


### PR DESCRIPTION
Both were recently added to translatewiki.

Bole autonym according to the review article
Schuh, Russell G. (October 1996).
"Dymitr Ibriszimow and Alhaji Maina Gimba (ed.):
Bole language and documentation Unit (BOLDU), Report I." Bulletin of the School of Oriental and African Studies. 59 (3): 620–621.

Karekare autonym according to the book
"Dindeno, asumka waɗo mabo Karai-karai"
Yobe Languages Research Project 2009
https://ucla.app.box.com/s/xvpgk2ecl73nwnjyyo7g80fsr96mtsbz