### PR TITLE
Add Komering

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -358,6 +358,8 @@ languages:
   kea: [Latn, [AF], kabuverdianu]
   ken: [Latn, [AF], kɛ́nyáŋ]
   kg: [Latn, [AF], Kongo]
+  kge: [Latn, [AS, PA], Basa Kumoring]
+  kge-arab: [Arab, [AS, PA], باس كوموريڠ]
   kgp: [Latn, [AM], Kaingáng]
   khk: [mn]
   khw: [Arab, [ME, AS], کھوار]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -2210,6 +2210,22 @@
             ],
             "Kongo"
         ],
+        "kge": [
+            "Latn",
+            [
+                "AS",
+                "PA"
+            ],
+            "Basa Kumoring"
+        ],
+        "kge-arab": [
+            "Arab",
+            [
+                "AS",
+                "PA"
+            ],
+            "باس كوموريڠ"
+        ],
         "kgp": [
             "Latn",
             [
@@ -5907,6 +5923,7 @@
             "mak",
             "rej",
             "gor",
+            "kge",
             "sly",
             "mwv"
         ],


### PR DESCRIPTION
Add the Komering language (Latin and Arabic scripts), recently added to Translatewiki.net. Autonyms according to Wikipedia and requester on Translatewiki.net.