### PR TITLE
Automatically recreate data/language-data.json

### DIFF
--- a/data/language-data.json
+++ b/data/language-data.json
@@ -821,7 +821,7 @@
             [
                 "AS"
             ],
-            "閩東語 / Mìng-dĕ̤ng-ngṳ̄"
+            "閩東語 \/ Mìng-dĕ̤ng-ngṳ̄"
         ],
         "cdo-hani": [
             "Hani",
@@ -989,7 +989,7 @@
             [
                 "AS"
             ],
-            "莆仙語 / Pó-sing-gṳ̂"
+            "莆仙語 \/ Pó-sing-gṳ̂"
         ],
         "cpx-hans": [
             "Hans",
@@ -3126,7 +3126,7 @@
             [
                 "AS"
             ],
-            "閩南語 / Bân-lâm-gú"
+            "閩南語 \/ Bân-lâm-gú"
         ],
         "nan-hani": [
             "Hani",
@@ -4146,7 +4146,7 @@
             [
                 "EU"
             ],
-            "srpskohrvatski / српскохрватски"
+            "srpskohrvatski \/ српскохрватски"
         ],
         "sh-cyrl": [
             "Cyrl",
@@ -5653,26 +5653,14 @@
             "ha"
         ],
         "CN": [
-            "zh-hans",
             "zh",
-            "wuu-hant",
-            "wuu-hans",
             "wuu",
             "yue-hans",
-            "yue-hant",
             "yue",
             "hsn",
-            "hak-hans",
             "hak",
-            "nan-latn-pehoeji",
-            "nan-latn-tailo",
-            "nan-hant",
-            "nan-hans",
             "nan",
-            "gan-hant",
-            "gan-hans",
             "gan",
-            "cdo",
             "ii",
             "ug-arab",
             "za",
@@ -6004,7 +5992,6 @@
         "HK": [
             "zh-hant",
             "zh",
-            "yue-hant",
             "yue",
             "en"
         ],
@@ -6177,6 +6164,7 @@
             "sdc",
             "fur",
             "egl",
+            "lld",
             "ca",
             "el",
             "pms",
@@ -6430,14 +6418,7 @@
         "MY": [
             "ms",
             "en",
-            "zh-hant",
-            "zh-hans",
             "zh",
-            "nan-latn-pehoeji",
-            "nan-latn-tailo",
-            "nan-hant",
-            "nan-hans",
-            "nan",
             "ta",
             "iba",
             "jv",
@@ -6574,11 +6555,6 @@
             "tsg",
             "zh-hant",
             "zh",
-            "nan-latn-pehoeji",
-            "nan-latn-tailo",
-            "nan-hant",
-            "nan-hans",
-            "nan",
             "cps",
             "krj",
             "bto"
@@ -6752,7 +6728,6 @@
         ],
         "SG": [
             "en",
-            "zh-hans",
             "zh",
             "ms",
             "ta",
@@ -6929,20 +6904,7 @@
         "TW": [
             "zh-hant",
             "zh",
-            "nan-latn-pehoeji",
-            "nan-latn-tailo",
-            "nan-hant",
-            "nan",
-            "hak-hant",
-            "hak",
-            "lzh",
-            "ami",
-            "szy",
-            "pwn",
-            "tay",
-            "trv",
-            "xsy",
-            "en"
+            "trv"
         ],
         "TZ": [
             "sw",


### PR DESCRIPTION
I mistakenly merged #314, in which this file was edited manually, and not automatically using the script.

This fixes names that use '/' and removes several
languages and variants of China and Taiwan.

This also adds Ladin "lld" to Italy.