### PR TITLE
Change mui autonym according to Ethnologue

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -484,7 +484,7 @@ languages:
   ms: [Latn, [AS], Bahasa Melayu]
   ms-arab: [Arab, [AS], بهاس ملايو]
   mt: [Latn, [EU], Malti]
-  mui: [Latn, [AS], Musi]
+  mui: [Latn, [AS], Baso Palembang]
   mus: [Latn, [AM], Mvskoke]
   mvf: [Mong, [AS], ᠮᠣᠩᠭᠣᠯ]
   mwl: [Latn, [EU], Mirandés]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -3045,7 +3045,7 @@
             [
                 "AS"
             ],
-            "Musi"
+            "Baso Palembang"
         ],
         "mus": [
             "Latn",


### PR DESCRIPTION
This language was added long ago when mui and plm
were separate codes, and mui was "Musi" and plm
was "Palembang". The code plm was retired in 2008
and the only valid code now is mui, and its autonym according to Ethnologue is "Baso Palembang".
This is also the name most commonly used by the
language's speakers according to the article
Alsamadani, Mardheya; Taibah, Samar (2019).
"Types and Functions of Reduplication in Palembang". Journal of the Southeast Asian Linguistics Society.