### PR TITLE
Add Ekpeye (ekp)

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -206,6 +206,7 @@ languages:
   ee: [Latn, [AF], eʋegbe]
   efi: [Latn, [AF], efịk]
   egl: [Latn, [EU], Emiliàn]
+  ekp: [Latn, [AF], ẹkpeye]
   el: [Grek, [EU], Ελληνικά]
   elm: [Latn, [AF], Eleme]
   eml: [Latn, [EU], emiliàn e rumagnòl]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -1239,6 +1239,13 @@
             ],
             "Emiliàn"
         ],
+        "ekp": [
+            "Latn",
+            [
+                "AF"
+            ],
+            "ẹkpeye"
+        ],
         "el": [
             "Grek",
             [


### PR DESCRIPTION
Requested at
https://translatewiki.net/w/i.php?title=Support&oldid=12410268#Translating_Wikicontents_to_Ekpeye

Autonym according to
Ngulube, Isaac (2011). "Ekpeye Orthography".
Orthographies of Nigerian Languages. IX.