### PR TITLE
Rename wlx autonym

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -798,7 +798,7 @@ languages:
   wal: [Latn, [AF], wolaytta]
   war: [Latn, [AS], Winaray]
   wls: [Latn, [PA], "Faka'uvea"]
-  wlx: [Latn, [AF], waalii]
+  wlx: [Latn, [AF], waale]
   wo: [Latn, [AF], Wolof]
   wsg: [Telu, [AS], గోండి]
   wuu: [Hani, [AS], 吴语]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -5057,7 +5057,7 @@
             [
                 "AF"
             ],
-            "waalii"
+            "waale"
         ],
         "wo": [
             "Latn",


### PR DESCRIPTION
wlx was recently added with the "waalii" autonym.
The translators asked to change the autonym,
and provided a reliable source:
https://translatewiki.net/w/i.php?title=Support&oldid=12497406#Requesting_Waali_language_with_language_code=wlx_to_be_added_to_Wikimedia