### PR TITLE
Add Tamazight (Latin) (zgh-latn)

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -825,6 +825,7 @@ languages:
   za: [Latn, [AS], Vahcuengh]
   zea: [Latn, [EU], Zeêuws]
   zgh: [Tfng, [AF], ⵜⴰⵎⴰⵣⵉⵖⵜ ⵜⴰⵏⴰⵡⴰⵢⵜ]
+  zgh-latn: [Latn, [AF], tamaziɣt tanawayt]
   zh: [Hani, [AS, PA, AM, WW], 中文]
   zh-cdo: [cdo]
   zh-classical: [lzh]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -5240,6 +5240,13 @@
             ],
             "ⵜⴰⵎⴰⵣⵉⵖⵜ ⵜⴰⵏⴰⵡⴰⵢⵜ"
         ],
+        "zgh-latn": [
+            "Latn",
+            [
+                "AF"
+            ],
+            "tamaziɣt tanawayt"
+        ],
         "zh": [
             "Hani",
             [


### PR DESCRIPTION
It has been used in core MediaWiki,
so it needs to be in language-data, too.