### PR TITLE
Remove ruq-grek

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -642,8 +642,6 @@ languages:
   rup: [Latn, [EU], armãneashti]
   ruq: [Cyrl, [EU], Влахесте]
   ruq-cyrl: [ruq]
- # FIXME: broken autonym
-  ruq-grek: [Grek, [EU], Megleno-Romanian (Greek script)]
   ruq-latn: [Latn, [EU], Vlăheşte]
   rut: [Cyrl, [EU], мыхаӀбишды]
   rw: [Latn, [AF], Ikinyarwanda]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -4052,13 +4052,6 @@
         "ruq-cyrl": [
             "ruq"
         ],
-        "ruq-grek": [
-            "Grek",
-            [
-                "EU"
-            ],
-            "Megleno-Romanian (Greek script)"
-        ],
         "ruq-latn": [
             "Latn",
             [


### PR DESCRIPTION
It was added to core MediaWiki long ago for
unclear reasons, but it was never actually
used for anything, and it's probably
not needed anywhere.

It was already removed from core MediaWiki, too.

ruq-latn and ruq-cyrl should probably be removed,
too, but they were actually used for some things
in core MediaWiki, so that needs to be cleaned up
first.

See also downstream bug:
https://phabricator.wikimedia.org/T357981