### PR TITLE
Update Solomon Islands Pidgin (pis) autonym

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -589,7 +589,7 @@ languages:
   phr: [Arab, [AS], پوٹھواری]
   pi: [Deva, [AS], पालि]
   pih: [Latn, [PA], Norfuk / Pitkern]
-  pis: [Latn, [PA], Pijin]
+  pis: [Latn, [PA], Solomon Aelan Pijin]
   piu: [Latn, [PA], Pintupi-Luritja]
   pjt: [Latn, [PA], Pitjantjatjara]
   pko: [Latn, [AF], Pökoot]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -3718,7 +3718,7 @@
             [
                 "PA"
             ],
-            "Pijin"
+            "Solomon Aelan Pijin"
         ],
         "piu": [
             "Latn",


### PR DESCRIPTION
Make it less ambiguous, so that it will be clearly distinct from other pidgin languages, and findable by country name.

This name is used, for example, here:
Beimers, Gerry (2009). Pijin: A Grammar of Solomon Islands Pidgin (PhD thesis). The University of New England. page 26

And can also easily be found in many other sources.