### PR TITLE
Add Central Kanuri as a full-fledged language

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -411,10 +411,7 @@ languages:
   kmb: [Latn, [AF], kimbundu]
   kmr: [ku-latn]
   kn: [Knda, [AS], ಕನ್ನಡ]
- # In ISO 639, it refers to Central Kanuri. It may
- # be changed like that here, too, but for
- # now, redirect it to macro Kanuri.
-  knc: [kr]
+  knc: [Latn, [AF], Yerwa Kanuri]
   knn: [Deva, [AS], महाराष्ट्रीय कोंकणी]
   ko: [Kore, [AS], 한국어]
   ko-kp: [Kore, [AS], 조선말]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -2573,7 +2573,11 @@
             "ಕನ್ನಡ"
         ],
         "knc": [
-            "kr"
+            "Latn",
+            [
+                "AF"
+            ],
+            "Yerwa Kanuri"
         ],
         "knn": [
             "Deva",


### PR DESCRIPTION
Autonym according to Ethnologue.

Downstream task:
https://phabricator.wikimedia.org/T356144