### PR TITLE
Add Awajún (agr)

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -19,6 +19,7 @@ languages:
   aeb-latn: [Latn, [AF], Tûnsî]
   af: [Latn, [AF], Afrikaans]
   agq: [Latn, [AF], aghɨ̂m]
+  agr: [Latn, [AM], Awajún]
   ahr: [Deva, [AS], अहिराणी]
   aig: [Latn, [AM], Aanteegan an' Baabyuudan]
   aii: [Syrc, [ME], ܣܘܪܝܬ]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -136,6 +136,13 @@
             ],
             "aghɨ̂m"
         ],
+        "agr": [
+            "Latn",
+            [
+                "AM"
+            ],
+            "Awajún"
+        ],
         "ahr": [
             "Deva",
             [


### PR DESCRIPTION
Please add the Awajún language, this language is spoken in northern Peru: https://en.wikipedia.org/wiki/Aguaruna_language. Thanks