### PR TITLE
Add mustangostang/spyc as a dev dependency in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,13 +31,13 @@
 		}
 	],
 	"require": {
-		"php": ">=8.0",
-		"mustangostang/spyc": "0.6.3"
+		"php": ">=8.0"
 	},
 	"require-dev": {
 		"ext-curl": "*",
 		"phpunit/phpunit": "9.6.20",
-		"mediawiki/mediawiki-codesniffer": "47.0.0"
+		"mediawiki/mediawiki-codesniffer": "47.0.0",
+		"mustangostang/spyc": "0.6.3"
 	},
 
 	"support": {


### PR DESCRIPTION
The above mentioned library is required for generationg `language-data.json` by parsing YAML langdb.yaml file. The script only runs when languages are added/removed/modified, so it does not impact normal operation. This change moved the library to a dev dependency.

Bug: [T410029](https://phabricator.wikimedia.org/T410029)