### PR TITLE
Update configuration to avoid unneeded files in release package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@
 .github/ export-ignore
 .gitignore export-ignore
 .phpcs.xml export-ignore
+.readthedocs.yaml export-ignore
 composer.json export-ignore
 composer.lock export-ignore
 docs/ export-ignore
@@ -12,3 +13,5 @@ package.json export-ignore
 phpunit.xml export-ignore
 tests/ export-ignore
 yaml-sort-checker.yml export-ignore
+data/langdb.yaml export-ignore
+src/util/ export-ignore

--- a/package.json
+++ b/package.json
@@ -21,6 +21,13 @@
     "Abijeet Patro"
   ],
   "main": "src/index.js",
+  "files": [
+    "src/index.js",
+    "data/language-data.json",
+    "CHANGELOG.md",
+    "COPYING",
+    "README.md"
+  ],
   "devDependencies": {
     "eslint": "8.57.0",
     "eslint-config-wikimedia": "0.32.3",


### PR DESCRIPTION
Updated both for packagist and npm

```
❯ npm pack --dry-run
npm notice
npm notice 📦  @wikimedia/language-data@2.0.0
npm notice Tarball Contents
npm notice 30.4kB CHANGELOG.md
npm notice 18.1kB COPYING
npm notice 2.2kB README.md
npm notice 138.6kB data/language-data.json
npm notice 1.1kB package.json
npm notice 8.1kB src/index.js
npm notice Tarball Details
npm notice name: @wikimedia/language-data
npm notice version: 2.0.0
npm notice filename: wikimedia-language-data-2.0.0.tgz
npm notice package size: 34.4 kB
npm notice unpacked size: 198.4 kB
npm notice shasum: 927786d47cb8e8b7d766f2ede08192246e0d928b
npm notice integrity: sha512-9FElaFaZPv7JD[...]5eG4JKZos/nWg==
npm notice total files: 6
npm notice
wikimedia-language-data-2.0.0.tgz
```