### PR TITLE
Add BCP 47 redirects for non-standard MediaWiki language codes

### DIFF
--- a/data/langdb.yaml
+++ b/data/langdb.yaml
@@ -392,6 +392,7 @@ languages:
   jv: [Latn, [AS, PA], Jawa]
  # For support in webfonts.
   jv-java: [Java, [AS, PA], ꦗꦮ]
+  jv-x-bms: [map-bms]
   ka: [Geor, [EU], ქართული]
   kaa: [Latn, [AS], Qaraqalpaqsha]
  # Can also be Tfng, but the Wikipedia is mostly Latn
@@ -565,6 +566,7 @@ languages:
   nan-latn-pehoeji: [Latn, [AS], Bân-lâm-gí (Pe̍h-ōe-jī)]
   nan-latn-tailo: [Latn, [AS], Bân-lâm-gí (Tâi-lô)]
   nap: [Latn, [EU], Napulitano]
+  nap-x-tara: [roa-tara]
   naq: [Latn, [AF], Khoekhoegowab]
   nb: [Latn, [EU], norsk (bokmål)]
   nd: [Latn, [AF], siNdebele saseNyakatho]
@@ -592,6 +594,7 @@ languages:
   npi: [ne]
   nqo: [Nkoo, [AF], ߒߞߏ]
   nr: [Latn, [AF], isiNdebele seSewula]
+  nrf: [nrm]
   nrf-gg: [Latn, [EU], Guernésiais]
   nrf-je: [Latn, [EU], Jèrriais]
   nrm: [Latn, [EU], Nouormand]
@@ -689,6 +692,7 @@ languages:
   rmy: [Latn, [EU], Romani]
   rn: [Latn, [AF], ikirundi]
   ro: [Latn, [EU], română]
+  ro-cyrl-md: [mo]
   roa-rup: [rup]
   roa-tara: [Latn, [EU], tarandíne]
   rsk: [Cyrl, [EU], руски]

--- a/data/language-data.json
+++ b/data/language-data.json
@@ -2472,6 +2472,9 @@
             ],
             "ꦗꦮ"
         ],
+        "jv-x-bms": [
+            "map-bms"
+        ],
         "ka": [
             "Geor",
             [
@@ -3617,6 +3620,9 @@
             ],
             "Napulitano"
         ],
+        "nap-x-tara": [
+            "roa-tara"
+        ],
         "naq": [
             "Latn",
             [
@@ -3796,6 +3802,9 @@
                 "AF"
             ],
             "isiNdebele seSewula"
+        ],
+        "nrf": [
+            "nrm"
         ],
         "nrf-gg": [
             "Latn",
@@ -4413,6 +4422,9 @@
                 "EU"
             ],
             "română"
+        ],
+        "ro-cyrl-md": [
+            "mo"
         ],
         "roa-rup": [
             "rup"
@@ -7421,7 +7433,19 @@
             "en",
             "zh",
             "ms",
+            "nan",
             "ta",
+            "hak",
+            "tl",
+            "yue",
+            "id",
+            "jv",
+            "bn",
+            "cdo",
+            "th",
+            "ja",
+            "cpx",
+            "mad",
             "ml",
             "pa"
         ],
@@ -7767,5 +7791,5 @@
             "tn"
         ]
     },
-    "version": "2026-04-15T14:20:00+00:00"
+    "version": "2026-04-23T08:24:56+00:00"
 }


### PR DESCRIPTION
MediaWiki core maps several non-standard wiki language codes to standard BCP 47 codes in HTML `lang=` attributes (via `LanguageCode.php`). The Universal Language Selector reads these `lang` attributes but cannot find the BCP 47 codes in the language database, causing those languages to be silently dropped from the Vector 2022 language sidebar.

This adds redirects for the 4 missing BCP 47 codes:
- `jv-x-bms` → `map-bms` (Basa Banyumasan)
- `nap-x-tara` → `roa-tara` (Tarandíne)
- `nrf` → `nrm` (Nouormand)
- `ro-cyrl-md` → `mo` (Moldovan)

Bug: https://phabricator.wikimedia.org/T391575